### PR TITLE
close#15, Removed overriding configuration file on exit, added reloading configuration file when modified and a few small bug fixes

### DIFF
--- a/dali-mqtt-daemon.py
+++ b/dali-mqtt-daemon.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
         exception_raised = True
         missing_key = e.args[0]
         config[missing_key] = args.__dict__[missing_key]
-        logger.info("Detected missing key in configuration file, please look at configuration file and reload demon")
+        logger.info("Detected missing key, configuration file updated")
     finally:
         if exception_raised:
             try:

--- a/dali-mqtt-daemon.py
+++ b/dali-mqtt-daemon.py
@@ -9,6 +9,10 @@ import yaml
 import json
 import io
 import re
+import asyncio
+import concurrent
+import os
+import time
 
 import paho.mqtt.client as mqtt
 
@@ -16,6 +20,9 @@ import dali.gear.general as gear
 import dali.exceptions
 import dali.address as address
 from dali.command import YesNoResponse, Response
+
+from watchdog.observers.polling import PollingObserver as Observer
+from watchdog.events import FileSystemEventHandler
 
 HASSEB = "hasseb"
 TRIDONIC = "tridonic"
@@ -25,7 +32,6 @@ DALI_DRIVERS = [HASSEB, TRIDONIC, DALI_SERVER]
 DEFAULT_MQTT_BASE_TOPIC = "dali2mqtt"
 DEFAULT_HA_DISCOVERY_PREFIX = "homeassistant"
 
-MQTT_BASE_TOPIC = DEFAULT_MQTT_BASE_TOPIC
 MQTT_DALI2MQTT_STATUS = "{}/status"
 MQTT_STATE_TOPIC = "{}/{}/light/status"
 MQTT_COMMAND_TOPIC = "{}/{}/light/switch"
@@ -38,18 +44,40 @@ MQTT_NOT_AVAILABLE = "offline"
 
 HA_DISCOVERY_PREFIX="{}/light/dali2mqtt_{}/config"
 
-def gen_ha_config(light):
+class ConfigFileSystemEventHandler(FileSystemEventHandler):
+    def __init__(self, mqqt_client, config, config_file_name, driver_object, loop):
+        super().__init__()
+        self.mqqt_client = mqqt_client
+        self.config_file_name = config_file_name
+        self.driver_object = driver_object
+        self.config = config
+        self.loop = loop
+    
+    def on_modified(self, event):
+        logger.info("Detected changes in configuration file {}, reloading".format(event.src_path))
+        self.config = load_config_file(self.config_file_name)
+        self.mqqt_client.loop_stop()
+        self.mqqt_client = create_mqtt_client(self.driver_object, self.config["dali_lamps"], self.config["mqtt_server"], self.config["mqtt_port"], self.config["mqtt_base_topic"], self.config["ha_discover_prefix"])
+        self.mqqt_client.loop_start()
+
+
+def load_config_file(path):
+    with open(path, 'r') as stream:
+        logger.debug("Loading configuration from <%s>", path)
+        return yaml.load(stream)
+
+def gen_ha_config(light, mqtt_base_topic):
     json_config = {
         "name": "DALI Light {}".format(light),
         "unique_id": "DALI2MQTT_LIGHT_{}".format(light),
-        "state_topic": MQTT_STATE_TOPIC.format(MQTT_BASE_TOPIC,light),
-        "command_topic": MQTT_COMMAND_TOPIC.format(MQTT_BASE_TOPIC,light), 
+        "state_topic": MQTT_STATE_TOPIC.format(mqtt_base_topic,light),
+        "command_topic": MQTT_COMMAND_TOPIC.format(mqtt_base_topic,light), 
         "payload_off": MQTT_PAYLOAD_OFF.decode("utf-8"),
-        "brightness_state_topic": MQTT_BRIGHTNESS_STATE_TOPIC.format(MQTT_BASE_TOPIC,light), 
-        "brightness_command_topic": MQTT_BRIGHTNESS_COMMAND_TOPIC.format(MQTT_BASE_TOPIC,light), 
+        "brightness_state_topic": MQTT_BRIGHTNESS_STATE_TOPIC.format(mqtt_base_topic,light), 
+        "brightness_command_topic": MQTT_BRIGHTNESS_COMMAND_TOPIC.format(mqtt_base_topic,light), 
         "brightness_scale": 254,
         "on_command_type": 'brightness',
-        "availability_topic": MQTT_DALI2MQTT_STATUS.format(MQTT_BASE_TOPIC),
+        "availability_topic": MQTT_DALI2MQTT_STATUS.format(mqtt_base_topic),
         "payload_available": MQTT_AVAILABLE,
         "payload_not_available": MQTT_NOT_AVAILABLE,
         "device": {
@@ -63,95 +91,83 @@ def gen_ha_config(light):
     return json.dumps(json_config)
 
 log_format = '%(asctime)s %(levelname)s: %(message)s'
-logging.basicConfig(format=log_format, level=logging.INFO)
+logging.basicConfig(format=log_format, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-def dali_scan(dali_driver, max_range=4):
+def dali_scan(driver_object, max_range=4):
     lamps = []
     for lamp in range(0,max_range):
         try:
             logging.debug("Search for Lamp {}".format(lamp))
-            r = dali_driver.send(gear.QueryControlGearPresent(address.Short(lamp)))
+            r = driver_object.send(gear.QueryControlGearPresent(address.Short(lamp)))
             if isinstance(r, YesNoResponse) and r.value:
                 lamps.append(lamp)
         except Exception as e:
             logger.warning("%s not present: %s", lamp, e)
     return lamps
 
-def on_message_cmd(mosq, dalic, msg):
+def on_message_cmd(mosq, data_object, msg):
     logger.debug("Command on %s: %s", msg.topic, msg.payload)
-    light = int(re.search(MQTT_COMMAND_TOPIC.format(MQTT_BASE_TOPIC, '(.+?)'), msg.topic).group(1))
+    light = int(re.search(MQTT_COMMAND_TOPIC.format(data_object['base_topic'], '(.+?)'), msg.topic).group(1))
     if msg.payload == MQTT_PAYLOAD_OFF:
         try:
             logger.debug("Set light <%s> to %s", light, msg.payload)
-            dalic.send(gear.Off(address.Short(light)))
-            mosq.publish(MQTT_STATE_TOPIC.format(MQTT_BASE_TOPIC, light), MQTT_PAYLOAD_OFF, retain=True)
+            data_object['driver'].send(gear.Off(address.Short(light)))
+            mosq.publish(MQTT_STATE_TOPIC.format(data_object['base_topic'], light), MQTT_PAYLOAD_OFF, retain=True)
         except:
             logger.error("Failed to set light <%s> to %s", light, "OFF")
 
-def on_message_brightness_cmd(mosq, dalic, msg):
+def on_message_brightness_cmd(mosq, data_object, msg):
     logger.debug("Brightness Command on %s: %s", msg.topic, msg.payload)
-    light = int(re.search(MQTT_BRIGHTNESS_COMMAND_TOPIC.format(MQTT_BASE_TOPIC, '(.+?)'), msg.topic).group(1))
+    light = int(re.search(MQTT_BRIGHTNESS_COMMAND_TOPIC.format(data_object['base_topic'], '(.+?)'), msg.topic).group(1))
     try:
         level = int(msg.payload.decode("utf-8"))
         if not 0 <= level <= 255:
             raise ValueError
         logger.debug("Set light <%s> brightness to %s", light, level)
-        r = dalic.send(gear.DAPC(address.Short(light), level))
+        r = data_object['driver'].send(gear.DAPC(address.Short(light), level))
         if level == 0:
             # 0 in DALI is turn off with fade out
-            mosq.publish(MQTT_STATE_TOPIC.format(MQTT_BASE_TOPIC, light), MQTT_PAYLOAD_OFF, retain=True)
+            mosq.publish(MQTT_STATE_TOPIC.format(data_object['base_topic'], light), MQTT_PAYLOAD_OFF, retain=True)
         else:
-            mosq.publish(MQTT_STATE_TOPIC.format(MQTT_BASE_TOPIC, light), MQTT_PAYLOAD_ON, retain=True)
-        mosq.publish(MQTT_BRIGHTNESS_STATE_TOPIC.format(MQTT_BASE_TOPIC, light), level, retain=True)
+            mosq.publish(MQTT_STATE_TOPIC.format(data_object['base_topic'], light), MQTT_PAYLOAD_ON, retain=True)
+        mosq.publish(MQTT_BRIGHTNESS_STATE_TOPIC.format(data_object['base_topic'], light), level, retain=True)
     except ValueError as e:
         logger.error("Can't convert <%s> to interger 0..255: %s", level, e)
 
-def on_message(mosq, dalic, msg):
+def on_message(mosq, data_object, msg):
     logger.error("Don't publish to %s", msg.topic)
 
-def on_connect(client, dalic, flags, result, max_lamps=4, ha_prefix=DEFAULT_HA_DISCOVERY_PREFIX):
-    client.subscribe([(MQTT_COMMAND_TOPIC.format(MQTT_BASE_TOPIC, "+"),0), (MQTT_BRIGHTNESS_COMMAND_TOPIC.format(MQTT_BASE_TOPIC, "+"),0)])
-    client.publish(MQTT_DALI2MQTT_STATUS.format(MQTT_BASE_TOPIC),MQTT_AVAILABLE,retain=True)
-    lamps = dali_scan(dalic, max_lamps)
+def on_connect(client, data_object, flags, result, max_lamps=4, ha_prefix=DEFAULT_HA_DISCOVERY_PREFIX):
+    mqqt_base_topic = data_object['base_topic']
+    driver_object = data_object['driver']
+    client.subscribe([(MQTT_COMMAND_TOPIC.format(mqqt_base_topic, "+"),0), (MQTT_BRIGHTNESS_COMMAND_TOPIC.format(mqqt_base_topic, "+"),0)])
+    client.publish(MQTT_DALI2MQTT_STATUS.format(mqqt_base_topic),MQTT_AVAILABLE,retain=True)
+    lamps = dali_scan(driver_object, max_lamps)
     for lamp in lamps:
         try:
-            r = dalic.send(gear.QueryActualLevel(address.Short(lamp)))
+            r = driver_object.send(gear.QueryActualLevel(address.Short(lamp)))
             logger.debug("QueryActualLevel = %s", r.value)
-            client.publish(HA_DISCOVERY_PREFIX.format(ha_prefix, lamp), gen_ha_config(lamp), retain=True)
-            client.publish(MQTT_BRIGHTNESS_STATE_TOPIC.format(MQTT_BASE_TOPIC, lamp), r.value, retain=True)
-            client.publish(MQTT_STATE_TOPIC.format(MQTT_BASE_TOPIC, lamp), MQTT_PAYLOAD_ON if r.value > 0 else MQTT_PAYLOAD_OFF, retain=True)
+            client.publish(HA_DISCOVERY_PREFIX.format(ha_prefix, lamp), gen_ha_config(lamp, mqqt_base_topic), retain=True)
+            client.publish(MQTT_BRIGHTNESS_STATE_TOPIC.format(mqqt_base_topic, lamp), r.value, retain=True)
+            client.publish(MQTT_STATE_TOPIC.format(mqqt_base_topic, lamp), MQTT_PAYLOAD_ON if r.value > 0 else MQTT_PAYLOAD_OFF, retain=True)
         except Exception as e:
             logger.error("While initializing lamp<%s>: %s", lamp, e)
 
-def main_loop(driver, max_lamps, mqtt_server, mqtt_port, ha_prefix):
-    dalic = None
-    logger.debug("Using <%s> driver", driver)
-    if driver == HASSEB:
-        from dali.driver.hasseb import SyncHassebDALIUSBDriver 
-        dalic = SyncHassebDALIUSBDriver()
-    elif driver == TRIDONIC:
-        from dali.driver.tridonic import SyncTridonicDALIUSBDriver
-        dalic = SyncTridonicDALIUSBDriver()
-    elif driver == DALI_SERVER:
-        from dali.driver.daliserver import DaliServer
-        dalic = DaliServer("localhost", 55825)    
-
+def create_mqtt_client(driver_object, max_lamps, mqtt_server, mqtt_port, mqqt_base_topic, ha_prefix):
     logger.debug("Connecting to %s:%s", mqtt_server, mqtt_port)
-    mqttc = mqtt.Client(client_id="dali2mqtt", userdata=dalic)
-    mqttc.will_set(MQTT_DALI2MQTT_STATUS.format(MQTT_BASE_TOPIC),MQTT_NOT_AVAILABLE,retain=True)
+    mqttc = mqtt.Client(client_id="dali2mqtt", userdata={'driver': driver_object, 'base_topic': mqqt_base_topic})
+    mqttc.will_set(MQTT_DALI2MQTT_STATUS.format(mqqt_base_topic),MQTT_NOT_AVAILABLE,retain=True)
     mqttc.on_connect = lambda a,b,c,d: on_connect(a,b,c,d, max_lamps, ha_prefix)
 
     # Add message callbacks that will only trigger on a specific subscription match.
-    mqttc.message_callback_add(MQTT_COMMAND_TOPIC.format(MQTT_BASE_TOPIC, '+'), on_message_cmd)
-    mqttc.message_callback_add(MQTT_BRIGHTNESS_COMMAND_TOPIC.format(MQTT_BASE_TOPIC, '+'), on_message_brightness_cmd)
+    mqttc.message_callback_add(MQTT_COMMAND_TOPIC.format(mqqt_base_topic, '+'), on_message_cmd)
+    mqttc.message_callback_add(MQTT_BRIGHTNESS_COMMAND_TOPIC.format(mqqt_base_topic, '+'), on_message_brightness_cmd)
     mqttc.on_message = on_message
     mqttc.connect(mqtt_server, mqtt_port, 60)
+    return mqttc
 
-    mqttc.loop_forever()
-
-
-if __name__ == "__main__":
+async def main(loop, executor):
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", help="configuration file", default="config.ini")
     parser.add_argument("--mqtt-server", help="MQTT server", default="localhost")
@@ -172,22 +188,44 @@ if __name__ == "__main__":
               }
 
     try:
-        with open(args.config, 'r') as stream:
-            logger.debug("Loading configuration from <%s>", args.config)
-            config = yaml.load(stream)
+        config = load_config_file(args.config)
 
-        MQTT_BASE_TOPIC = config["mqtt_base_topic"]
+        driver_object = None
+        driver = args.dali_driver
+        logger.debug("Using <%s> driver", driver)
+        if driver == HASSEB:
+            from dali.driver.hasseb import SyncHassebDALIUSBDriver 
+            driver_object = SyncHassebDALIUSBDriver()
+        elif driver == TRIDONIC:
+            from dali.driver.tridonic import SyncTridonicDALIUSBDriver
+            driver_object = SyncTridonicDALIUSBDriver()
+        elif driver == DALI_SERVER:
+            from dali.driver.daliserver import DaliServer
+            driver_object = DaliServer("localhost", 55825)    
 
-        main_loop(config["dali_driver"], config["dali_lamps"], config["mqtt_server"], config["mqtt_port"], config["ha_discover_prefix"])
+        mqqtc = create_mqtt_client(driver_object, config["dali_lamps"], config["mqtt_server"], config["mqtt_port"], config["mqtt_base_topic"], config["ha_discover_prefix"])
+        mqqtc.loop_start()
+
+        watchdog_observer = Observer()
+        watchdog_event_handler = ConfigFileSystemEventHandler(mqqtc, config, args.config, driver_object, loop)
+        watchdog_observer.schedule(watchdog_event_handler, args.config)
+        watchdog_observer.start()
     except FileNotFoundError as e:
-        logger.info("Configuration file %s created, please reload daemon", args.config)
-    except KeyError as e:
-        missing_key = e.args[0]
-        config[missing_key] = args.__dict__[missing_key]
-        logger.info("Configuration file updated, please reload daemon")
-    finally:
         try:
             with io.open(args.config, 'w', encoding="utf8") as outfile:
                 yaml.dump(config, outfile, default_flow_style=False, allow_unicode=True)
+                logger.info("Configuration file %s created, please reload daemon", args.config)
         except Exception as err:
-            logger.error(f"Could not save configuration: {err}")
+            logger.error(f"Could not save configuration: {err}")   
+    while True:
+        continue
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    executor = concurrent.futures.ThreadPoolExecutor(os.cpu_count() * 5)
+    loop.run_until_complete(main(loop, executor))
+    loop.close()
+
+
+    

--- a/dali-mqtt-daemon.py
+++ b/dali-mqtt-daemon.py
@@ -155,12 +155,7 @@ def create_mqtt_client(driver_object, max_lamps, mqtt_server, mqtt_port, mqqt_ba
     mqttc.connect(mqtt_server, mqtt_port, 60)
     return mqttc
 
-def main_loop(config_file_name, driver_object, config_watchdog_event_handler):
-    while True:
-        config = load_config_file(config_file_name)
-        mqqtc = create_mqtt_client(driver_object, config["dali_lamps"], config["mqtt_server"], config["mqtt_port"], config["mqtt_base_topic"], config["ha_discover_prefix"])
-        config_watchdog_event_handler.mqqt_client = mqqtc
-        mqqtc.loop_forever()
+    
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -202,7 +197,12 @@ if __name__ == "__main__":
         watchdog_event_handler.on_modified = lambda event: on_detect_changes_in_config(event, watchdog_event_handler.mqqt_client)
         watchdog_observer.schedule(watchdog_event_handler, args.config)
         watchdog_observer.start()
-        main_loop(args.config, driver_object, watchdog_event_handler)
+        
+        while True:
+            config = load_config_file(args.config)
+            mqqtc = create_mqtt_client(driver_object, config["dali_lamps"], config["mqtt_server"], config["mqtt_port"], config["mqtt_base_topic"], config["ha_discover_prefix"])
+            watchdog_event_handler.mqqt_client = mqqtc
+            mqqtc.loop_forever()
     except FileNotFoundError as e:
         exception_raised = True
         logger.info("Configuration file %s created, please reload daemon", args.config)

--- a/dali-mqtt-daemon.py
+++ b/dali-mqtt-daemon.py
@@ -11,8 +11,6 @@ import io
 import re
 import asyncio
 import concurrent
-import os
-import time
 
 import paho.mqtt.client as mqtt
 
@@ -42,6 +40,7 @@ MQTT_PAYLOAD_OFF = b"OFF"
 MQTT_AVAILABLE = "online"
 MQTT_NOT_AVAILABLE = "offline"
 
+THREAD_EXECUTORS = 2
 HA_DISCOVERY_PREFIX="{}/light/dali2mqtt_{}/config"
 
 class ConfigFileSystemEventHandler(FileSystemEventHandler):
@@ -91,7 +90,7 @@ def gen_ha_config(light, mqtt_base_topic):
     return json.dumps(json_config)
 
 log_format = '%(asctime)s %(levelname)s: %(message)s'
-logging.basicConfig(format=log_format, level=logging.DEBUG)
+logging.basicConfig(format=log_format, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def dali_scan(driver_object, max_range=4):
@@ -223,7 +222,7 @@ async def main(loop, executor):
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()
-    executor = concurrent.futures.ThreadPoolExecutor(os.cpu_count() * 5)
+    executor = concurrent.futures.ThreadPoolExecutor(THREAD_EXECUTORS)
     loop.run_until_complete(main(loop, executor))
     loop.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 paho-mqtt==1.4.0
 pathtools==0.1.2
-pyhidapi==1.0.0
+git+git://github.com/awelkie/pyhidapi@master#egg=pyhidapi==1.0.0
 python-dali==0.7
 pyusb==1.0.2
 PyYAML==3.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 paho-mqtt==1.4.0
+pathtools==0.1.2
+pyhidapi==1.0.0
 python-dali==0.7
 pyusb==1.0.2
 PyYAML==3.13
+watchdog==0.10.3
 wheel


### PR DESCRIPTION
Hello, I made a few changes to script and I:
* Fixed a bug described in #15 
   * Now change configuration file will reload a script on-fly without exit (but changing a driver requires exit)
   * I added also package [watchdog](https://github.com/gorakhargosh/watchdog) to watch configuration file for changes
   * Changing a config file when script is runned doesn't override file on exit
* Updated a `requirements.txt` and I probably by mistake fix a small bug described in #11 
* Found a bug, changing `mqtt_base_topic` wasn't change topic in MQTT (fixed)
* Added asyncio and run main loop in new thread (so script isn't blocked)
