### PR TITLE
close#19, Support for log-level

### DIFF
--- a/consts.py
+++ b/consts.py
@@ -1,3 +1,5 @@
+import logging
+
 """Constants common the various modules."""
 HASSEB = "hasseb"
 TRIDONIC = "tridonic"
@@ -18,3 +20,11 @@ MQTT_AVAILABLE = "online"
 MQTT_NOT_AVAILABLE = "offline"
 
 HA_DISCOVERY_PREFIX = "{}/light/dali2mqtt_{}/config"
+
+ALL_SUPPORTED_LOG_LEVELS = {
+    "critical": logging.CRITICAL,
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+}

--- a/dali-mqtt-daemon.py
+++ b/dali-mqtt-daemon.py
@@ -46,6 +46,7 @@ YELLOW_COLOR = "\x1b[33;21m"
 
 class ConfigFileSystemEventHandler(FileSystemEventHandler):
     """Event Handler for config file changes."""
+
     def __init__(self):
         super().__init__()
         self.mqqt_client = None
@@ -89,7 +90,7 @@ def gen_ha_config(light, mqtt_base_topic):
 
 
 log_format = "%(asctime)s %(levelname)s: %(message)s{}".format(RESET_COLOR)
-logging.basicConfig(format=log_format, level=logging.INFO)
+logging.basicConfig(format=log_format)
 logger = logging.getLogger(__name__)
 
 
@@ -266,6 +267,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ha-discover-prefix", help="HA discover mqtt prefix", default="homeassistant"
     )
+    parser.add_argument("--log-level", help="Log level", default="info")
     parser.add_argument("--log-color", help="Coloring output", action="store_true")
 
     args = parser.parse_args()
@@ -290,6 +292,21 @@ if __name__ == "__main__":
 
     exception_raised = False
     try:
+        all_supported_log_levels = {
+            "critical": logging.CRITICAL,
+            "error": logging.ERROR,
+            "warning": logging.WARNING,
+            "info": logging.INFO,
+            "debug": logging.DEBUG,
+        }
+        args.log_level = args.log_level.lower()
+        if args.log_level not in all_supported_log_levels:
+            logger.error(
+                "Unsupported log level {}! Changed to level info".format(args.log_level)
+            )
+            args.log_level = "info"
+        logger.setLevel(all_supported_log_levels[args.log_level])
+
         driver_object = None
         driver = args.dali_driver
         logger.debug("Using <%s> driver", driver)

--- a/dali-mqtt-daemon.py
+++ b/dali-mqtt-daemon.py
@@ -35,6 +35,7 @@ from consts import (
     MQTT_PAYLOAD_OFF,
     MQTT_PAYLOAD_ON,
     MQTT_STATE_TOPIC,
+    ALL_SUPPORTED_LOG_LEVELS,
     TRIDONIC,
 )
 
@@ -266,7 +267,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ha-discover-prefix", help="HA discover mqtt prefix", default="homeassistant"
     )
-    parser.add_argument("--log-level", help="Log level", default="info")
+    parser.add_argument(
+        "--log-level",
+        help="Log level",
+        choices=ALL_SUPPORTED_LOG_LEVELS,
+        default="info",
+    )
     parser.add_argument("--log-color", help="Coloring output", action="store_true")
 
     args = parser.parse_args()
@@ -290,20 +296,7 @@ if __name__ == "__main__":
     }
 
     exception_raised = False
-    all_supported_log_levels = {
-        "critical": logging.CRITICAL,
-        "error": logging.ERROR,
-        "warning": logging.WARNING,
-        "info": logging.INFO,
-        "debug": logging.DEBUG,
-    }
-    args.log_level = args.log_level.lower()
-    if args.log_level not in all_supported_log_levels:
-        logger.error(
-            "Unsupported log level {}! Changed to level info".format(args.log_level)
-        )
-        args.log_level = "info"
-    logger.setLevel(all_supported_log_levels[args.log_level])
+    logger.setLevel(ALL_SUPPORTED_LOG_LEVELS[args.log_level])
     try:
         dali_driver = None
         logger.debug("Using <%s> driver", args.dali_driver)

--- a/dali-mqtt-daemon.py
+++ b/dali-mqtt-daemon.py
@@ -88,13 +88,8 @@ def gen_ha_config(light, mqtt_base_topic):
     return json.dumps(json_config)
 
 
-<<<<<<< HEAD
 log_format = "%(asctime)s %(levelname)s: %(message)s{}".format(RESET_COLOR)
 logging.basicConfig(format=log_format)
-=======
-LOG_FORMAT = "%(asctime)s %(levelname)s: %(message)s{}".format(RESET_COLOR)
-logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
->>>>>>> 41121dd6764dede58862c780c99ca1542c2fcb6b
 logger = logging.getLogger(__name__)
 
 
@@ -176,7 +171,7 @@ def on_message_brightness_cmd(mqtt_client, data_object, msg):
         logger.error("Can't convert <%s> to interger 0..255: %s", level, err)
 
 
-def on_message(mqtt_client, data_object, msg): # pylint: disable=W0613
+def on_message(mqtt_client, data_object, msg):  # pylint: disable=W0613
     """Default callback on MQTT message."""
     logger.error("Don't publish to %s", msg.topic)
 
@@ -188,7 +183,7 @@ def on_connect(
     result,
     max_lamps=4,
     ha_prefix=DEFAULT_HA_DISCOVERY_PREFIX,
-): # pylint: disable=W0613,R0913
+):  # pylint: disable=W0613,R0913
     """Callback on connection to MQTT server."""
     mqqt_base_topic = data_object["base_topic"]
     driver_object = data_object["driver"]


### PR DESCRIPTION
In this PR I added support for argument `--log-level` which support all known levels from [logger docs](https://docs.python.org/3/library/logging.html#levels), default is still `info`