### PR TITLE
#32, Preventing changing the configuration every run of dali2mqtt

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,21 +69,45 @@ class Config:
         self.load_config_file()
 
         # Overwrite with command line arguments
-        if self._config.get(CONF_MQTT_SERVER) != args.mqtt_server:
+        if (
+            self._config.get(CONF_MQTT_SERVER) != args.mqtt_server
+            and args.mqtt_server != DEFAULT_MQTT_SERVER
+        ):
             self._config[CONF_MQTT_SERVER] = args.mqtt_server
-        if self._config.get(CONF_MQTT_PORT) != args.mqtt_port:
+        if (
+            self._config.get(CONF_MQTT_PORT) != args.mqtt_port
+            and args.mqtt_port != DEFAULT_MQTT_PORT
+        ):
             self._config[CONF_MQTT_PORT] = args.mqtt_port
-        if self._config.get(CONF_MQTT_BASE_TOPIC) != args.mqtt_base_topic:
+        if (
+            self._config.get(CONF_MQTT_BASE_TOPIC) != args.mqtt_base_topic
+            and args.mqtt_base_topic != DEFAULT_MQTT_BASE_TOPIC
+        ):
             self._config[CONF_MQTT_BASE_TOPIC] = args.mqtt_base_topic
-        if self._config.get(CONF_DALI_DRIVER) != args.dali_driver:
+        if (
+            self._config.get(CONF_DALI_DRIVER) != args.dali_driver
+            and args.dali_driver != DEFAULT_DALI_DRIVER
+        ):
             self._config[CONF_DALI_DRIVER] = args.dali_driver
-        if self._config.get(CONF_DALI_LAMPS) != args.dali_lamps:
+        if (
+            self._config.get(CONF_DALI_LAMPS) != args.dali_lamps
+            and args.dali_lamps != DEFAULT_DALI_LAMPS
+        ):
             self._config[CONF_DALI_LAMPS] = args.dali_lamps
-        if self._config.get(CONF_HA_DISCOVERY_PREFIX) != args.ha_discovery_prefix:
+        if (
+            self._config.get(CONF_HA_DISCOVERY_PREFIX) != args.ha_discovery_prefix
+            and args.ha_discovery_prefix != DEFAULT_HA_DISCOVERY_PREFIX
+        ):
             self._config[CONF_HA_DISCOVERY_PREFIX] = args.ha_discovery_prefix
-        if self._config.get(CONF_LOG_LEVEL) != args.log_level:
+        if (
+            self._config.get(CONF_LOG_LEVEL) != args.log_level
+            and args.log_level != DEFAULT_LOG_LEVEL
+        ):
             self._config[CONF_LOG_LEVEL] = args.log_level
-        if self._config.get(CONF_LOG_COLOR) != args.log_color:
+        if (
+            self._config.get(CONF_LOG_COLOR) != args.log_color
+            and args.log_color != DEFAULT_LOG_COLOR
+        ):
             self._config[CONF_LOG_COLOR] = args.log_color
 
         self.save_config_file()

--- a/dali_mqtt_daemon.py
+++ b/dali_mqtt_daemon.py
@@ -27,6 +27,7 @@ from consts import (
     DEFAULT_CONFIG_FILE,
     DEFAULT_MQTT_PORT,
     DEFAULT_MQTT_SERVER,
+    DEFAULT_DALI_DRIVER,
     DEFAULT_HA_DISCOVERY_PREFIX,
     DEFAULT_MQTT_BASE_TOPIC,
     DEFAULT_LOG_LEVEL,
@@ -311,7 +312,10 @@ if __name__ == "__main__":
         "--mqtt-base-topic", help="MQTT base topic", default=DEFAULT_MQTT_BASE_TOPIC
     )
     parser.add_argument(
-        "--dali-driver", help="DALI device driver", choices=DALI_DRIVERS, default=HASSEB
+        "--dali-driver",
+        help="DALI device driver",
+        choices=DALI_DRIVERS,
+        default=DEFAULT_DALI_DRIVER,
     )
     parser.add_argument(
         "--dali-lamps", help="Number of lamps to scan", type=int, default=4
@@ -319,7 +323,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ha-discovery-prefix",
         help="HA discovery mqtt prefix",
-        default="homeassistant",
+        default=DEFAULT_HA_DISCOVERY_PREFIX,
     )
     parser.add_argument(
         "--log-level",
@@ -327,7 +331,12 @@ if __name__ == "__main__":
         choices=ALL_SUPPORTED_LOG_LEVELS,
         default=DEFAULT_LOG_LEVEL,
     )
-    parser.add_argument("--log-color", help="Coloring output", action="store_true")
+    parser.add_argument(
+        "--log-color",
+        help="Coloring output",
+        action="store_true",
+        default=DEFAULT_LOG_COLOR,
+    )
 
     args = parser.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 paho-mqtt==1.4.0
 pathtools==0.1.2
 git+git://github.com/awelkie/pyhidapi@master#egg=pyhidapi==1.0.0
-python-dali==0.7.1
+python-dali==0.7
 pyusb==1.0.2
 PyYAML==3.13
-voluptuous==0.11.7
 watchdog==0.10.3
+voluptuous==0.11.7
 wheel


### PR DESCRIPTION
In this PR:
* Preventing changing the configuration every run of dali2mqtt
   * Using `DEFAULT_*` consts in `argparse` - I guess, you added default consts but forget change `default` parameter in invoke `add_argument`?
* Adding missing `voluptuous` to `requirements.txt`