### PR TITLE
test: expand test coverage for lamp and devicesnamesconfig

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ def test_load_config():
     cfg = Config(args)
 
     assert cfg.mqtt_conf == ('localhost', 1883, None, None, 'dali2mqtt')
-    assert cfg,dali_driver == "hasseb"
+    assert cfg.dali_driver == "hasseb"
     assert cfg.ha_discovery_prefix == "homeassistant"
     assert cfg.log_level == "info"
     assert cfg.log_color == False

--- a/tests/test_devicesnamesconfig.py
+++ b/tests/test_devicesnamesconfig.py
@@ -1,0 +1,128 @@
+"""Tests for DevicesNamesConfig."""
+
+import os
+import tempfile
+import pytest
+import yaml
+from dali2mqtt.devicesnamesconfig import DevicesNamesConfig, DevicesNamesConfigLoadError
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def config_file(temp_dir):
+    return os.path.join(temp_dir, "devices.yaml")
+
+
+@pytest.fixture
+def config_with_devices(temp_dir):
+    """Create a config file with some devices."""
+    path = os.path.join(temp_dir, "devices.yaml")
+    data = {
+        0: {"friendly_name": "Living Room"},
+        1: {"friendly_name": "Kitchen"},
+    }
+    with open(path, "w") as f:
+        yaml.dump(data, f)
+    return path
+
+
+def test_load_existing_config(config_with_devices):
+    """Test loading an existing config file."""
+    config = DevicesNamesConfig("info", config_with_devices)
+    assert config.get_friendly_name(0) == "Living Room"
+    assert config.get_friendly_name(1) == "Kitchen"
+
+
+def test_get_friendly_name_unknown_address(config_file):
+    """Test getting friendly name for unknown address returns address as string."""
+    config = DevicesNamesConfig("info", config_file)
+    assert config.get_friendly_name(99) == "99"
+
+
+def test_is_devices_file_empty_true(config_file):
+    """Test that empty file returns True."""
+    config = DevicesNamesConfig("info", config_file)
+    assert config.is_devices_file_empty() is True
+
+
+def test_is_devices_file_empty_false(config_with_devices):
+    """Test that non-empty file returns False."""
+    config = DevicesNamesConfig("info", config_with_devices)
+    assert config.is_devices_file_empty() is False
+
+
+def test_save_devices_names_file(config_file):
+    """Test saving device names to file."""
+    config = DevicesNamesConfig("info", config_file)
+
+    # Create mock lamp objects
+    lamp1 = type(
+        "Lamp",
+        (),
+        {"short_address": type("Addr", (), {"address": 0})()},
+    )()
+    lamp2 = type(
+        "Lamp",
+        (),
+        {"short_address": type("Addr", (), {"address": 1})()},
+    )()
+
+    all_lamps = {"lamp1": lamp1, "lamp2": lamp2}
+    config.save_devices_names_file(all_lamps)
+
+    # Reload and verify
+    config2 = DevicesNamesConfig("info", config_file)
+    assert config2.get_friendly_name(0) == "0"
+    assert config2.get_friendly_name(1) == "1"
+
+
+def test_load_invalid_yaml_raises(temp_dir):
+    """Test that invalid YAML raises DevicesNamesConfigLoadError."""
+    path = os.path.join(temp_dir, "bad.yaml")
+    with open(path, "w") as f:
+        f.write("{{invalid yaml content")
+
+    with pytest.raises(DevicesNamesConfigLoadError):
+        DevicesNamesConfig("info", path)
+
+
+def test_load_devices_names_file(config_with_devices):
+    """Test explicit load_devices_names_file call."""
+    config = DevicesNamesConfig("info", config_with_devices)
+    # Should not raise
+    config.load_devices_names_file()
+    assert config.get_friendly_name(0) == "Living Room"
+
+
+def test_get_friendly_name_returns_string(config_with_devices):
+    """Test that get_friendly_name always returns a string."""
+    config = DevicesNamesConfig("info", config_with_devices)
+    result = config.get_friendly_name(0)
+    assert isinstance(result, str)
+
+    # Unknown address should also return string
+    result = config.get_friendly_name(999)
+    assert isinstance(result, str)
+    assert result == "999"
+
+
+def test_save_and_reload_roundtrip(config_file):
+    """Test that save → load roundtrip preserves data."""
+    config = DevicesNamesConfig("info", config_file)
+
+    lamp1 = type(
+        "Lamp",
+        (),
+        {"short_address": type("Addr", (), {"address": 42})()},
+    )()
+    config.save_devices_names_file({"lamp1": lamp1})
+
+    # Reload
+    config2 = DevicesNamesConfig("info", config_file)
+    assert config2.get_friendly_name(42) == "42"
+    assert not config2.is_devices_file_empty()

--- a/tests/test_lamp_level.py
+++ b/tests/test_lamp_level.py
@@ -1,0 +1,171 @@
+"""Tests for lamp level handling edge cases."""
+
+from dali2mqtt.lamp import Lamp
+from unittest import mock
+from dali.address import Short
+import pytest
+
+
+MIN_PHYSICAL_BRIGHTNESS = 1
+MIN_BRIGHTNESS = 2
+MAX_BRIGHTNESS = 250
+ACTUAL_BRIGHTNESS = 100
+
+
+def generate_driver_values(results):
+    for res in results:
+        result = mock.Mock()
+        result.value = res
+        yield result
+
+
+@pytest.fixture
+def fake_driver():
+    """Driver with enough values for Lamp.__init__.
+
+    Init consumes 5 driver calls:
+    1. QueryPhysicalMinimum -> MIN_PHYSICAL_BRIGHTNESS
+    2. QueryMinLevel -> MIN_BRIGHTNESS
+    3. QueryMaxLevel -> MAX_BRIGHTNESS
+    4. QueryActualLevel -> ACTUAL_BRIGHTNESS (.value)
+    5. DAPC (from level setter in __init__) -> ACTUAL_BRIGHTNESS
+    """
+    drive = mock.Mock()
+    drive.dummy = generate_driver_values(
+        [MIN_PHYSICAL_BRIGHTNESS, MIN_BRIGHTNESS, MAX_BRIGHTNESS, ACTUAL_BRIGHTNESS, ACTUAL_BRIGHTNESS]
+    )
+    drive.send = lambda x: next(drive.dummy)
+    return drive
+
+
+@pytest.fixture
+def lamp(fake_driver):
+    """A fully initialized Lamp with a mock driver."""
+    return Lamp(
+        log_level="debug",
+        driver=fake_driver,
+        friendly_name="test lamp",
+        short_address=Short(1),
+    )
+
+
+def test_level_setter_valid_value(lamp):
+    """Test setting a valid brightness level."""
+    lamp.driver = mock.Mock()
+    lamp.level = 50
+    assert lamp.level == 50
+
+
+def test_level_setter_zero(lamp):
+    """Test that 0 is always accepted (turn off)."""
+    lamp.driver = mock.Mock()
+    lamp.level = 0
+    assert lamp.level == 0
+
+
+def test_level_setter_max_boundary(lamp):
+    """Test setting level to max boundary."""
+    lamp.driver = mock.Mock()
+    lamp.level = MAX_BRIGHTNESS
+    assert lamp.level == MAX_BRIGHTNESS
+
+
+def test_level_setter_min_boundary(lamp):
+    """Test setting level to min boundary."""
+    lamp.driver = mock.Mock()
+    lamp.level = MIN_BRIGHTNESS
+    assert lamp.level == MIN_BRIGHTNESS
+
+
+def test_level_setter_above_max_raises(lamp):
+    """Test that level above max raises ValueError."""
+    lamp.driver = mock.Mock()
+    with pytest.raises(ValueError):
+        lamp.level = MAX_BRIGHTNESS + 1
+
+
+def test_level_setter_below_min_nonzero_raises(lamp):
+    """Test that level below min (non-zero) raises ValueError."""
+    lamp.driver = mock.Mock()
+    with pytest.raises(ValueError):
+        lamp.level = MIN_BRIGHTNESS - 1
+
+
+def test_level_setter_string_value_raises(lamp):
+    """Test that string value (e.g., MASK) raises TypeError.
+
+    DALI devices may return 'MASK' when a value is not available.
+    This currently causes TypeError on int/str comparison.
+    Issue: https://github.com/dgomes/dali2mqtt/issues/64
+    """
+    lamp.driver = mock.Mock()
+    with pytest.raises(TypeError):
+        lamp.level = "MASK"
+
+
+def test_level_setter_nan_raises(lamp):
+    """Test that NaN value is handled.
+
+    NaN comparison with int always returns False, so the bounds check
+    `not min_level <= value <= max_level` would be True (NaN comparisons
+    are always False), and with value != 0 also True, so it raises ValueError.
+    """
+    lamp.driver = mock.Mock()
+    with pytest.raises(ValueError):
+        lamp.level = float("nan")
+
+
+def test_off_method(lamp):
+    """Test turning off the lamp."""
+    lamp.driver = mock.Mock()
+    lamp.off()
+    lamp.driver.send.assert_called_once()
+
+
+def test_str_representation(lamp):
+    """Test string representation of lamp."""
+    result = str(lamp)
+    assert "test-lamp" in result
+    assert "address: 1" in result
+    assert f"actual brightness level: {ACTUAL_BRIGHTNESS}" in result
+    assert f"minimum: {MIN_BRIGHTNESS}" in result
+    assert f"max: {MAX_BRIGHTNESS}" in result
+
+
+def test_actual_level_updates(lamp):
+    """Test that actual_level() queries the driver and updates __level."""
+    mock_response = mock.Mock()
+    mock_response.value = 75
+    lamp.driver = mock.Mock()
+    lamp.driver.send.return_value = mock_response
+    lamp.actual_level()
+    # actual_level stores the raw response (not .value)
+    assert lamp.level == mock_response
+
+
+def test_gen_ha_config_returns_valid_json(lamp):
+    """Test that gen_ha_config returns valid JSON."""
+    import json
+
+    config_json = lamp.gen_ha_config("test_topic")
+    config = json.loads(config_json)
+    assert config["name"] == "test lamp"
+    assert "stat_t" in config
+    assert "cmd_t" in config
+    assert "bri_scl" in config
+    assert config["bri_scl"] == MAX_BRIGHTNESS
+
+
+def test_level_setter_sends_dapc(lamp):
+    """Test that setting level sends DAPC command to driver."""
+    lamp.driver = mock.Mock()
+    lamp.level = 50
+    lamp.driver.send.assert_called_once()
+
+
+def test_level_setter_int_value_accepted(lamp):
+    """Test that int values are properly handled."""
+    lamp.driver = mock.Mock()
+    for val in [MIN_BRIGHTNESS, 100, MAX_BRIGHTNESS, 0]:
+        lamp.level = val
+        assert lamp.level == val


### PR DESCRIPTION
## Summary
Expand test coverage for lamp.py and devicesnamesconfig.py, fix assertion typo in test_config.py.

## Motivation
Addresses #37 — "Create more tests". The project had a seed test suite but lacked coverage for lamp level edge cases and the DevicesNamesConfig class.

## Changes
- **Fix typo in test_config.py**: `cfg,dali_driver` → `cfg.dali_driver` (was a tuple comparison, always truthy, masking a real assertion)
- **Add test_lamp_level.py** (14 tests):
  - Level setter: valid values, boundaries, out-of-range, zero
  - Edge cases: string input (MASK — relates to #64), NaN input
  - Methods: `off()`, `actual_level()`, `gen_ha_config()`
  - DAPC command verification
- **Add test_devicesnamesconfig.py** (10 tests):
  - Load existing config, save/reload roundtrip
  - Unknown address handling, empty file check
  - Invalid YAML error handling

## Verification
```
pytest -vvv tests/  # 26 passed
flake8 tests/test_lamp_level.py tests/test_devicesnamesconfig.py --max-line-length=127  # 0 errors
```

Note: Pre-existing flake8 issues in test_config.py, test_hasseb.py, and test_lamp.py are not addressed in this PR (separate concern).